### PR TITLE
Fixed: Add missing comma in setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -27,7 +27,7 @@ setuptools.setup(
         "Programming Language :: Python :: 3",
         "License :: OSI Approved :: Apache Software License",
         "Operating System :: OS Independent",
-        "Intended Audience :: Developers"
+        "Intended Audience :: Developers",
         "Topic :: Software Development :: Build Tools"
     ],
     scripts=["src/termux-create-package"],


### PR DESCRIPTION
This was necessary to publish an updated to pypi, as otherwise the string gets concatenated, resulting in an invalid field.