### PR TITLE
Fix import of 'importlib'

### DIFF
--- a/src/termux-create-package
+++ b/src/termux-create-package
@@ -34,7 +34,7 @@ import time
 import traceback
 import unicodedata
 
-import importlib
+import importlib.util
 yaml_supported = False
 try:
     if importlib.util.find_spec("ruamel.yaml") is not None:

--- a/tests/tests_main.py
+++ b/tests/tests_main.py
@@ -9,7 +9,7 @@ Usage:        Run from repo root.
 """
 
 import os
-import importlib
+import importlib.util
 import sys
 
 


### PR DESCRIPTION
Fixes the script to actually run. Otherwise, this error was thrown (and ignored):

AttributeError: module 'importlib' has no attribute 'util'