### PR TITLE
Fix bitwise inversion warning

### DIFF
--- a/src/termux-create-package
+++ b/src/termux-create-package
@@ -1574,9 +1574,9 @@ def get_effective_mode(current_mode, symbolic, file_type=None):
             ("o" in clazz and "t" in perm and stat.S_ISVTX)
     else:
         new_mode = new_mode & \
-            ~("u" in clazz and "s" in perm and stat.S_ISUID) & \
-            ~("g" in clazz and "s" in perm and stat.S_ISGID) & \
-            ~("o" in clazz and "t" in perm and stat.S_ISVTX)
+            ~int("u" in clazz and "s" in perm and stat.S_ISUID) & \
+            ~int("g" in clazz and "s" in perm and stat.S_ISGID) & \
+            ~int("o" in clazz and "t" in perm and stat.S_ISVTX)
 
     return new_mode
 

--- a/src/termux-create-package
+++ b/src/termux-create-package
@@ -34,7 +34,7 @@ import time
 import traceback
 import unicodedata
 
-import importlib
+import importlib.util
 yaml_supported = False
 try:
     if importlib.util.find_spec("ruamel.yaml") is not None:

--- a/tests/tests_main.py
+++ b/tests/tests_main.py
@@ -9,7 +9,7 @@ Usage:        Run from repo root.
 """
 
 import os
-import importlib
+import importlib.util
 import sys
 
 


### PR DESCRIPTION
Fixes these warnings by using `~int()` instead of `~()`:
```
/usr/local/bin/termux-create-package:1579: DeprecationWarning: Bitwise inversion '~' on bool is deprecated and will be removed in Python 3.16. This returns the bitwise inversion of the underlying int object and is usually not what you expect from negating a bool. Use the 'not' operator for boolean negation or ~int(x) if you really want the bitwise inversion of the underlying int.
  ~("o" in clazz and "t" in perm and stat.S_ISVTX)
/usr/local/bin/termux-create-package:1577: DeprecationWarning: Bitwise inversion '~' on bool is deprecated and will be removed in Python 3.16. This returns the bitwise inversion of the underlying int object and is usually not what you expect from negating a bool. Use the 'not' operator for boolean negation or ~int(x) if you really want the bitwise inversion of the underlying int.
  ~("u" in clazz and "s" in perm and stat.S_ISUID) & \
/usr/local/bin/termux-create-package:1578: DeprecationWarning: Bitwise inversion '~' on bool is deprecated and will be removed in Python 3.16. This returns the bitwise inversion of the underlying int object and is usually not what you expect from negating a bool. Use the 'not' operator for boolean negation or ~int(x) if you really want the bitwise inversion of the underlying int.
  ~("g" in clazz and "s" in perm and stat.S_ISGID) & \
```

This PR is based off of #56, because that's the only way I can run tests. Though changes themselves can be merged independently, they are in the last commit.